### PR TITLE
content: replace AI-generated copy with chill, direct writing

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -10,7 +10,7 @@ const today = new Date();
 			<div>
 				<p class="m-0 text-sm font-medium text-foreground">{SITE_TITLE}</p>
 				<p class="m-0 mt-1 text-sm text-muted-foreground">
-					A small organization sharing what we learn about infrastructure, cloud, Kubernetes, SRE, and DevOps.
+					Infra stuff, written down.
 				</p>
 			</div>
 
@@ -32,7 +32,7 @@ const today = new Date();
 
 		<div class="flex flex-col gap-2 border-t border-border/70 pt-4 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
 			<p class="m-0">&copy; {today.getFullYear()} Pelindung Bumi.</p>
-			<p class="m-0">We learn, write, and share with curiosity.</p>
+			<p class="m-0">We run into problems, figure them out, and write them down.</p>
 		</div>
 	</div>
 </footer>

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,7 +1,7 @@
 export const SITE_TITLE = 'Pelindung Bumi';
-export const SITE_TAGLINE = 'Infra notes for curious operators';
+export const SITE_TAGLINE = 'Just infra things.';
 export const SITE_DESCRIPTION =
-	'Pelindung Bumi is a small organization sharing what we learn about infrastructure, Kubernetes, cloud, SRE, DevOps, and related technology.';
+	'Pelindung Bumi is Rivaldo, Leo, and Rolando. We work with infrastructure, Kubernetes, cloud, and SRE — and write down anything worth remembering.';
 export const GITHUB_URL = 'https://github.com/pelindung-bumi';
 export const GITHUB_OWNER = 'pelindung-bumi';
 export const GITHUB_REPO = 'pelindung-bumi.github.io';

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -16,38 +16,36 @@ import { GITHUB_URL, SITE_DESCRIPTION, SITE_TITLE } from '../consts';
 			<section class="surface-panel p-6 sm:p-8 lg:p-10">
 				<div class="page-intro max-w-4xl">
 					<span class="section-label">About</span>
-					<h1 class="display-title text-[clamp(2.8rem,6vw,5rem)]">We are curious people learning technology together.</h1>
+					<h1 class="display-title text-[clamp(2.8rem,6vw,5rem)]">Three people. One obsession with how systems work.</h1>
 					<p class="lede max-w-3xl">
-						Pelindung Bumi is an organization built around curiosity. We like studying technical
-						topics, writing down what we learn, and sharing that learning with anyone who finds it
-						useful.
+						Pelindung Bumi is Rivaldo, Leo, and Rolando. We work on infra, break things, fix them,
+						and write about it.
 					</p>
 				</div>
 			</section>
 
 			<section class="mt-10 section-grid cols-2">
 				<div class="info-card">
-					<p class="eyebrow">What we learn</p>
+					<p class="eyebrow">What we write about</p>
 					<h3 class="mt-3">Infrastructure and the systems around it</h3>
 					<p>
-						Our interests stay close to infrastructure, Kubernetes, cloud, SRE, DevOps, and other
-						technical areas that help people understand how modern systems are built and operated.
+						Kubernetes, cloud, SRE, DevOps — the stuff that keeps systems running and the people
+						who have to deal with it when it doesn't.
 					</p>
 				</div>
 				<div class="info-card">
-					<p class="eyebrow">Why this exists</p>
-					<h3 class="mt-3">We share while we are still learning</h3>
+					<p class="eyebrow">Why we publish</p>
+					<h3 class="mt-3">Waiting until you feel ready means never publishing.</h3>
 					<p>
-						We do not want to wait until we feel like experts. We prefer to learn in public,
-						capture useful lessons, and let the writing grow with our understanding.
+						We write when things are still fresh. Notes from last week beat a polished post that
+						never ships.
 					</p>
 				</div>
 				<div class="info-card">
 					<p class="eyebrow">The name</p>
-					<h3 class="mt-3">Pelindung Bumi is just a cool name</h3>
+					<h3 class="mt-3">It means "Earth Protector" in Indonesian.</h3>
 					<p>
-						There is no superhero story here. We simply liked the name. What gives it meaning is
-						the organization behind it and the things we choose to share.
+						We liked how it sounds. That's it.
 					</p>
 				</div>
 				<div class="info-card">

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -28,10 +28,9 @@ const posts = await Promise.all(
 		<main class="page-shell py-10 sm:py-14">
 			<div class="page-intro max-w-3xl">
 				<span class="section-label">Blog</span>
-				<h1 class="display-title text-[clamp(2.8rem,6vw,5rem)]">Notes from people who are still learning.</h1>
+				<h1 class="display-title text-[clamp(2.8rem,6vw,5rem)]">Everything we've written down.</h1>
 				<p class="lede">
-					This blog collects what we are learning about infrastructure, Kubernetes, cloud, SRE,
-					DevOps, and nearby topics. We try to keep the writing simple, useful, and honest.
+					Infrastructure, Kubernetes, cloud, SRE, DevOps. Pick something and read.
 				</p>
 			</div>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -25,13 +25,11 @@ const latestPost = (await getCollection('blog')).sort(
 					<div class="surface-panel p-6 sm:p-8 lg:p-10">
 						<span class="section-label">Organization</span>
 						<h1 class="display-title mt-6 max-w-4xl">
-							Curious people learning technology and sharing it with the world.
+							We run systems and write about them.
 						</h1>
 						<p class="lede mt-6 max-w-2xl">
-							Pelindung Bumi is a small organization for people who enjoy learning about
-							infrastructure, Kubernetes, cloud, SRE, DevOps, and related engineering topics.
-							We are not superheroes. Pelindung Bumi is simply a cool name for a group that likes
-							to study, write, and share what we discover.
+							Pelindung Bumi is Rivaldo, Leo, and Rolando. We work with infrastructure,
+							Kubernetes, cloud, and SRE — and write down anything worth remembering.
 						</p>
 						<div class="mt-8 flex flex-wrap gap-3">
 							<a class="button-link primary" href="/blog">Read the blog</a>
@@ -53,8 +51,7 @@ const latestPost = (await getCollection('blog')).sort(
 						<div class="article-note">
 							<h3>Why we write</h3>
 							<p class="mt-3">
-								We write to document what we are learning and make that learning useful for other
-								people who are also curious about technology.
+								So we don't forget how we fixed it last time.
 							</p>
 						</div>
 					</div>
@@ -64,33 +61,29 @@ const latestPost = (await getCollection('blog')).sort(
 			<section class="page-shell mt-16">
 				<div class="page-intro">
 					<span class="section-label">What matters to us</span>
-					<h2 class="section-title">Learning in public, one topic at a time</h2>
+					<h2 class="section-title">What we're into</h2>
 					<p class="lede max-w-3xl">
-						We care about understanding how systems work, how teams keep them reliable, and how
-						new learners can approach technical topics without pretending to know everything.
+						Infrastructure, Kubernetes, cloud, SRE, DevOps. Pick something and read.
 					</p>
 				</div>
 
 				<div class="section-grid cols-3">
 					<div class="info-card">
-						<h3>Shared curiosity</h3>
+						<h3>Infrastructure</h3>
 						<p>
-							We are people who like asking questions, reading docs, trying things, and turning
-							that process into writing others can use.
+							Servers, networks, storage, and everything that sits underneath the apps people actually use.
 						</p>
 					</div>
 					<div class="info-card">
-						<h3>Technical focus</h3>
+						<h3>Kubernetes & Cloud</h3>
 						<p>
-							Our attention stays around infrastructure, Kubernetes, cloud, SRE, DevOps, and the
-							daily habits that help systems stay understandable.
+							Clusters, deployments, cloud providers — the stuff that either works perfectly or ruins your weekend.
 						</p>
 					</div>
 					<div class="info-card">
-						<h3>Open sharing</h3>
+						<h3>SRE & DevOps</h3>
 						<p>
-							We share what we learn as we go, even when it starts small. The goal is progress,
-							not performance.
+							Three engineers and their notes. We run into problems, figure them out, and write them down.
 						</p>
 					</div>
 				</div>
@@ -100,7 +93,7 @@ const latestPost = (await getCollection('blog')).sort(
 				<section class="page-shell mt-16">
 					<div class="page-intro">
 						<span class="section-label">Latest post</span>
-						<h2 class="section-title">Start with the latest thing we learned</h2>
+						<h2 class="section-title">Latest post</h2>
 					</div>
 
 					<a class="post-card no-underline" href={`/blog/${latestPost.id}/`}>
@@ -122,10 +115,9 @@ const latestPost = (await getCollection('blog')).sort(
 				<div class="section-grid cols-2">
 					<div class="info-card">
 						<p class="eyebrow">About us</p>
-						<h3 class="mt-3">A name, a direction, and a habit of learning</h3>
+						<h3 class="mt-3">Who we are</h3>
 						<p>
-							Pelindung Bumi is just a cool name. What matters more is the habit behind it: keep
-							learning, keep writing, and keep sharing useful things with others.
+							We run into problems, figure them out, and write them down. That's the whole thing.
 						</p>
 					</div>
 					<div class="info-card">


### PR DESCRIPTION
Rewrites all placeholder/cringe copy across homepage, blog listing, about page, footer, and site constants. Same topics, better tone.

- Hero: "We run systems and write about them."
- Blog: "Everything we've written down."
- About: "Three people. One obsession with how systems work."
- Footer: "Infra stuff, written down."
<img width="1459" height="791" alt="image" src="https://github.com/user-attachments/assets/568d2b36-a613-4dc6-b8ad-6c1dc9808bfe" />
